### PR TITLE
feat(chat): add speech-to-text for voice messages

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -212,6 +212,14 @@
       "useFile": "Use this file",
       "cancel": "Cancel"
     },
+    "stt": {
+      "transcribe": "Convert to text",
+      "transcribing": "Transcribing...",
+      "success": "Transcribed successfully",
+      "failed": "Failed to transcribe",
+      "noSpeech": "No speech detected in this audio",
+      "alreadyTranscribed": "Already transcribed"
+    },
     "messages": {
       "you": "You",
       "empty": {

--- a/public/locales/vi/common.json
+++ b/public/locales/vi/common.json
@@ -208,6 +208,14 @@
       "useFile": "Dùng file này",
       "cancel": "Hủy"
     },
+    "stt": {
+      "transcribe": "Chuyển thành văn bản",
+      "transcribing": "Đang nhận dạng...",
+      "success": "Đã chuyển thành văn bản",
+      "failed": "Không thể nhận dạng giọng nói",
+      "noSpeech": "Không phát hiện giọng nói trong audio",
+      "alreadyTranscribed": "Đã có bản chuyển"
+    },
     "messages": {
       "you": "Bạn",
       "empty": {

--- a/src/components/chat/file/CompactFileGallery.tsx
+++ b/src/components/chat/file/CompactFileGallery.tsx
@@ -50,12 +50,19 @@ interface CompactFileGalleryProps {
   files: FilePreview[];
   maxDisplay?: number; // Số file hiển thị tối đa, còn lại show "+N"
   className?: string;
+  /**
+   * Parent message id — required so audio attachments can call the
+   * Speech-to-Text endpoint (which needs both attachmentId and messageId
+   * for ownership validation).
+   */
+  messageId?: string;
 }
 
 export const CompactFileGallery = ({
   files,
   maxDisplay = 3,
   className = "",
+  messageId,
 }: CompactFileGalleryProps) => {
   const { t } = useTranslation();
   const [selectedFile, setSelectedFile] = useState<FilePreview | null>(null);
@@ -169,7 +176,7 @@ export const CompactFileGallery = ({
         )}
 
         {fileKind === "audio" && (
-          <div className="w-full h-full flex items-center justify-center bg-default-100 dark:bg-default-50">
+          <div className="w-full bg-default-100 dark:bg-default-50 p-2 flex flex-col gap-1">
             <MiniAudioBubble
               src={file.url}
               initialDuration={
@@ -180,7 +187,10 @@ export const CompactFileGallery = ({
               onPlayChange={() => {
                 // nếu sau này muốn stop các audio khác -> xử lý ở parent
               }}
-              className="w-full px-2"
+              className="w-full"
+              attachmentId={file._id}
+              messageId={messageId}
+              initialTranscript={file.transcript ?? null}
             />
           </div>
         )}

--- a/src/components/chat/file/MiniAudioBubble.tsx
+++ b/src/components/chat/file/MiniAudioBubble.tsx
@@ -1,8 +1,13 @@
 // MiniAudioBubble.tsx
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { PlayIcon, PauseIcon } from "@heroicons/react/24/solid";
+import {
+  PlayIcon,
+  PauseIcon,
+  DocumentTextIcon,
+} from "@heroicons/react/24/solid";
 import { useTranslation } from "react-i18next";
+import { aiService } from "@/service/ai.service";
 
 function fmt(t: number) {
   if (!isFinite(t) || t <= 0) return "0:00";
@@ -12,21 +17,57 @@ function fmt(t: number) {
   return `${m}:${sec}`;
 }
 
-export default function MiniAudioBubble({
-  src,
-  initialDuration,
-  className = "",
-  onPlayChange, // optional callback khi play/pause
-}: {
+interface MiniAudioBubbleProps {
   src: string;
   initialDuration?: number; // giây (nếu đã có sẵn từ server)
   className?: string;
   onPlayChange?: (isPlaying: boolean) => void;
-}) {
-  const { t } = useTranslation();
+  /**
+   * IDs needed to call Speech-to-Text. When BOTH provided, a "Convert to
+   * text" button renders next to the play button. The audio is fetched
+   * server-side from S3 — FE only sends the IDs to `/ai/transcribe-attachment`.
+   */
+  attachmentId?: string;
+  messageId?: string;
+  /**
+   * Existing transcript loaded with the message (from `attachment.transcript`
+   * field on the BE). When set, the button is hidden and the transcript
+   * is rendered immediately. `null` / `undefined` means not transcribed yet.
+   */
+  initialTranscript?: string | null;
+}
+
+export default function MiniAudioBubble({
+  src,
+  initialDuration,
+  className = "",
+  onPlayChange,
+  attachmentId,
+  messageId,
+  initialTranscript,
+}: MiniAudioBubbleProps) {
+  const { t, i18n } = useTranslation();
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [isPlaying, setPlaying] = useState(false);
   const [dur, setDur] = useState(initialDuration ?? 0);
+
+  // Local transcript state — initialized from prop, mutated by the
+  // transcribe button. This lets the user see their own transcript
+  // immediately without waiting for a message-store roundtrip.
+  const [transcript, setTranscript] = useState<string | null>(
+    initialTranscript ?? null,
+  );
+  const [transcribing, setTranscribing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Sync local state when the parent reloads a message that already has
+  // transcript persisted (e.g., page refresh, or another user transcribed
+  // and the message gets re-fetched).
+  useEffect(() => {
+    if (typeof initialTranscript === "string") {
+      setTranscript(initialTranscript);
+    }
+  }, [initialTranscript]);
 
   useEffect(() => {
     const a = new Audio(src);
@@ -68,70 +109,135 @@ export default function MiniAudioBubble({
     }
   };
 
+  const handleTranscribe = async () => {
+    if (!attachmentId || !messageId || transcribing) return;
+    // Avoid re-running when we already have a transcript locally.
+    if (typeof transcript === "string") return;
+
+    setTranscribing(true);
+    setError(null);
+    try {
+      const lang: "vi" | "en" = i18n.language === "en" ? "en" : "vi";
+      const res = await aiService.transcribeAttachment(
+        attachmentId,
+        messageId,
+        lang,
+      );
+      setTranscript(res.transcript ?? "");
+    } catch (err) {
+      console.error("[stt] transcribe failed", err);
+      setError(t("chat.stt.failed"));
+    } finally {
+      setTranscribing(false);
+    }
+  };
+
   const bars = useMemo(() => {
     // 18 cột cao dần nhìn giống Messenger
     return new Array(18).fill(0).map((_, i) => i);
   }, []);
 
+  const showTranscribeButton =
+    !!attachmentId && !!messageId && typeof transcript !== "string";
+
   return (
-    <div
-      className={`flex items-center gap-3 w-full rounded-2xl px-3 py-2
-                  bg-gradient-to-r from-blue-600 to-blue-500 text-white shadow-sm ${className}`}
-    >
-      <button
-        onClick={toggle}
-        className="shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-full bg-white/25 hover:bg-white/35 transition"
-        aria-label={
-          isPlaying ? t("chat.file.audio.pause") : t("chat.file.audio.play")
-        }
+    <div className="flex flex-col gap-1 w-full">
+      <div
+        className={`flex items-center gap-3 w-full rounded-2xl px-3 py-2
+                  bg-linear-to-r from-blue-600 to-blue-500 text-white shadow-sm ${className}`}
       >
-        {isPlaying ? (
-          <PauseIcon className="w-4 h-4" />
-        ) : (
-          <PlayIcon className="w-4 h-4" />
-        )}
-      </button>
+        <button
+          onClick={toggle}
+          className="shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-full bg-white/25 hover:bg-white/35 transition"
+          aria-label={
+            isPlaying ? t("chat.file.audio.pause") : t("chat.file.audio.play")
+          }
+        >
+          {isPlaying ? (
+            <PauseIcon className="w-4 h-4" />
+          ) : (
+            <PlayIcon className="w-4 h-4" />
+          )}
+        </button>
 
-      {/* Cột sóng */}
-      <div className="flex-1 min-w-0 h-8 flex items-end gap-[3px]">
-        {bars.map((i) => (
-          <span
-            key={i}
-            className={`w-[4px] bg-white/90 rounded-sm origin-bottom
+        {/* Cột sóng */}
+        <div className="flex-1 min-w-0 h-8 flex items-end gap-0.75">
+          {bars.map((i) => (
+            <span
+              key={i}
+              className={`w-1 bg-white/90 rounded-sm origin-bottom
               ${isPlaying ? "animate-voicebar" : ""}`}
-            style={{
-              height: `${6 + i * 2}px`, // cao dần
-              animationDelay: `${(i % 6) * 80}ms`,
-            }}
-          />
-        ))}
+              style={{
+                height: `${6 + i * 2}px`, // cao dần
+                animationDelay: `${(i % 6) * 80}ms`,
+              }}
+            />
+          ))}
+        </div>
+
+        <div className="shrink-0 text-[12px] font-semibold tabular-nums">
+          {fmt(dur)}
+        </div>
+
+        {/* "Convert to text" button — only shown when we can call STT and
+            don't already have a transcript. Compact icon-only button to
+            avoid making the audio bubble overflow on narrow chat columns. */}
+        {showTranscribeButton && (
+          <button
+            onClick={handleTranscribe}
+            disabled={transcribing}
+            className="shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-full bg-white/25 hover:bg-white/35 transition disabled:opacity-60 disabled:cursor-wait"
+            aria-label={t("chat.stt.transcribe")}
+            title={t("chat.stt.transcribe")}
+          >
+            {transcribing ? (
+              <span className="w-3 h-3 border-2 border-white/80 border-t-transparent rounded-full animate-spin" />
+            ) : (
+              <DocumentTextIcon className="w-4 h-4" />
+            )}
+          </button>
+        )}
+
+        {/* audio ẩn */}
+        <audio src={src} className="hidden" />
+        <style jsx>{`
+          @keyframes voicebar {
+            0% {
+              transform: scaleY(0.6);
+              opacity: 0.85;
+            }
+            50% {
+              transform: scaleY(1.1);
+              opacity: 1;
+            }
+            100% {
+              transform: scaleY(0.6);
+              opacity: 0.85;
+            }
+          }
+          .animate-voicebar {
+            animation: voicebar 900ms ease-in-out infinite;
+          }
+        `}</style>
       </div>
 
-      <div className="shrink-0 text-[12px] font-semibold tabular-nums">
-        {fmt(dur)}
-      </div>
-
-      {/* audio ẩn */}
-      <audio src={src} className="hidden" />
-      <style jsx>{`
-        @keyframes voicebar {
-          0% {
-            transform: scaleY(0.6);
-            opacity: 0.85;
-          }
-          50% {
-            transform: scaleY(1.1);
-            opacity: 1;
-          }
-          100% {
-            transform: scaleY(0.6);
-            opacity: 0.85;
-          }
-        }
-        .animate-voicebar {
-          animation: voicebar 900ms ease-in-out infinite;
-        }
-      `}</style>
+      {/* Transcript inline — sits below the audio bubble. Empty string
+          (transcript === "") means audio was processed but no speech was
+          detected; show a hint instead of an empty card. Errors render in
+          red but don't block the user from retrying. */}
+      {typeof transcript === "string" && (
+        <div className="text-xs leading-relaxed px-3 py-2 rounded-lg bg-default-100 dark:bg-default-50 text-default-700 dark:text-default-200">
+          <span className="text-default-500 dark:text-default-400 mr-1">
+            📄
+          </span>
+          {transcript.length > 0 ? transcript : t("chat.stt.noSpeech")}
+        </div>
+      )}
+      {error && (
+        <div className="text-xs px-3 py-1 rounded-lg bg-danger/10 text-danger">
+          {error}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/chat/message/MessageItem.tsx
+++ b/src/components/chat/message/MessageItem.tsx
@@ -457,6 +457,7 @@ export const MessageItem = memo(
                             files={msg.attachments}
                             maxDisplay={2}
                             className="w-full"
+                            messageId={msg.id || msg._id}
                           />
                         </div>
                       )}

--- a/src/service/ai.service.ts
+++ b/src/service/ai.service.ts
@@ -30,6 +30,15 @@ export interface TranslationResponse {
   to: string;
 }
 
+export interface TranscribeAttachmentResponse {
+  transcript: string;
+  detectedLanguage?: string;
+  attachmentId: string;
+  messageId: string;
+  /** True when BE returned a previously-saved transcript without re-running AI. */
+  cached?: boolean;
+}
+
 export const aiService = {
   search: async (
     query: string,
@@ -92,6 +101,37 @@ export const aiService = {
       translated: response.data?.metadata ?? "",
       from,
       to,
+    };
+  },
+
+  /**
+   * Speech-to-Text on an existing voice-message audio attachment.
+   *
+   * The audio is already on S3 (uploaded as part of the voice message),
+   * so we only send the IDs — BE fetches the file server-side and persists
+   * the transcript onto the Attachment record. Subsequent calls for the
+   * same attachment return the cached transcript without re-running AI
+   * (`response.cached === true`).
+   */
+  transcribeAttachment: async (
+    attachmentId: string,
+    messageId: string,
+    language: "vi" | "en" = "vi"
+  ): Promise<TranscribeAttachmentResponse> => {
+    const response = await apiService.post<{
+      metadata: TranscribeAttachmentResponse;
+    }>("/ai/transcribe-attachment", {
+      attachmentId,
+      messageId,
+      language,
+    });
+    const m = response.data?.metadata;
+    return {
+      transcript: m?.transcript ?? "",
+      detectedLanguage: m?.detectedLanguage,
+      attachmentId: m?.attachmentId ?? attachmentId,
+      messageId: m?.messageId ?? messageId,
+      cached: m?.cached ?? false,
     };
   },
 };

--- a/src/store/types/message.state.ts
+++ b/src/store/types/message.state.ts
@@ -26,6 +26,15 @@ export type FilePreview = {
   file?: File; // File gốc để upload
   uploadError?: any; // optional structured error info when upload failed
   summary?: string; // AI Summary of the attachment
+  /**
+   * Speech-to-Text transcript for audio attachments. Populated by the BE
+   * (`POST /ai/transcribe-attachment`) on demand when the user clicks the
+   * "Convert to text" button on a voice message bubble. `null` /
+   * `undefined` means not yet transcribed; empty string means the audio
+   * was processed but no speech detected.
+   */
+  transcript?: string | null;
+  transcribedAt?: string | null;
 };
 
 export type MessageSummary = {


### PR DESCRIPTION
Introduce a new Speech-to-Text feature for voice message attachments. Users can now convert audio content into text via a dedicated "Convert to text" button on voice message bubbles. This commit includes:

- New translations for STT status messages in English and Vietnamese.
- `messageId` support in `CompactFileGallery` to validate audio ownership for STT requests.
- `MiniAudioBubble` component updates to show a transcript or transcription button.
- An AI service method to handle the server-side transcription request.
- `FilePreview` now includes `transcript` to store STT results.

These changes aim to enhance the accessibility and searchability of audio messages by leveraging AI for transcription.